### PR TITLE
Bevy 0.12 Update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-steamworks"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["james7132 <contact@jamessliu.com>"]
 edition = "2021"
 description = "A Bevy plugin for integrating with the Steamworks SDK."
@@ -10,13 +10,14 @@ keywords = ["bevy", "gamedev", "steam"]
 
 [features]
 default = []
+serde = ["steamworks/serde"]
 
 [dependencies]
-bevy_log = "0.11"
-bevy_app = "0.11"
-bevy_ecs = "0.11"
-bevy_utils = "0.11"
+bevy_log = "0.12"
+bevy_app = "0.12"
+bevy_ecs = "0.12"
+bevy_utils = "0.12"
 steamworks = "0.10"
 
 [dev-dependencies]
-bevy = "0.11"
+bevy = "0.12"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bevy-steamworks = "0.8"
+bevy-steamworks = "0.9"
 ```
 
 The steamworks crate comes bundled with the redistributable dynamic libraries
@@ -76,6 +76,7 @@ fn main() {
  
 |Bevy Version |bevy\_steamworks|
 |:------------|:---------------|
+|0.12         |0.9             |
 |0.11         |0.8             |
 |0.10         |0.7             |
 |0.9          |0.6             |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and can be used to make requests via the SDK from any of Bevy's threads. However
 any asynchronous callbacks from Steam will only run on the main thread.
 
 The plugin will automatically call `SingleClient::run_callbacks` on the Bevy
-main thread every frame in `CoreStage::First`, so there is no need to run it
+main thread every frame in `First`, so there is no need to run it
 manually.
 
 **NOTE**: If the plugin fails to initialize (i.e. `Client::init()` fails and

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ fn main() {
   // Use the demo Steam AppId for SpaceWar
   App::new()
       .add_plugins(DefaultPlugins)
-      .add_plugin(SteamworksPlugin::new(AppId(480)))
+      .add_plugins(SteamworksPlugin::new(AppId(480)))
       .run()
 }
 ```
@@ -73,7 +73,7 @@ fn main() {
   // Use the demo Steam AppId for SpaceWar
   App::new()
       .add_plugins(DefaultPlugins)
-      .add_plugin(SteamworksPlugin::new(AppId(480)))
+      .add_plugins(SteamworksPlugin::new(AppId(480)))
       .add_startup_system(steam_system)
       .run()
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ bevy-steamworks = "0.9"
 The steamworks crate comes bundled with the redistributable dynamic libraries
 of a compatible version of the SDK. Currently it's v153a.
 
+If you wish to enable serde support add the following:
+
+```toml
+[dependencies]
+bevy-steamworks = { version = "0.9", features = ["serde"] }
+```
+
 ## Usage
 
 To add the plugin to your app, simply add the `SteamworksPlugin` to your

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ fn main() {
   App::new()
       .add_plugins(DefaultPlugins)
       .add_plugins(SteamworksPlugin::new(AppId(480)))
-      .add_startup_system(steam_system)
+      .add_systems(Startup, steam_system)
       .run()
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!   App::new()
 //!       .add_plugins(DefaultPlugins)
 //!       .add_plugins(SteamworksPlugin::new(AppId(480)))
-//!       .add_startup_system(steam_system)
+//!       .add_systems(Startup, steam_system)
 //!       .run()
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,8 +191,8 @@ impl Plugin for SteamworksPlugin {
                     ))
                     .insert_non_send_resource(single)
                     .add_event::<SteamworksEvent>()
-                    .configure_set(First, SteamworksSystem::RunCallbacks)
-                    .configure_set(
+                    .configure_sets(First, SteamworksSystem::RunCallbacks)
+                    .configure_sets(
                         First,
                         SteamworksSystem::FlushEvents.after(SteamworksSystem::RunCallbacks),
                     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! any asynchronous callbacks from Steam will only run on the main thread.
 //!
 //! The plugin will automatically call [`SingleClient::run_callbacks`] on the Bevy
-//! main thread every frame in [`CoreStage::First`], so there is no need to run it
+//! main thread every frame in [`First`], so there is no need to run it
 //! manually.
 //!
 //! **NOTE**: If the plugin fails to initialize (i.e. `Client::init()` fails and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!   // Use the demo Steam AppId for SpaceWar
 //!   App::new()
 //!       .add_plugins(DefaultPlugins)
-//!       .add_plugin(SteamworksPlugin::new(AppId(480)))
+//!       .add_plugins(SteamworksPlugin::new(AppId(480)))
 //!       .run()
 //! }
 //! ```
@@ -54,7 +54,7 @@
 //!   // Use the demo Steam AppId for SpaceWar
 //!   App::new()
 //!       .add_plugins(DefaultPlugins)
-//!       .add_plugin(SteamworksPlugin::new(AppId(480)))
+//!       .add_plugins(SteamworksPlugin::new(AppId(480)))
 //!       .add_startup_system(steam_system)
 //!       .run()
 //! }


### PR DESCRIPTION
This updates to Bevy 0.12 and fixes the deprecation warning by changing `configure_set` to `configure_sets`. Additionally, this exposes the steamworks dependency's serde feature via a feature of the same name in this crate disabled by default, fixing #21.